### PR TITLE
Async JS method invocations

### DIFF
--- a/AllJoyn/Platform/Bridge/BridgeCore/Bridge.cpp
+++ b/AllJoyn/Platform/Bridge/BridgeCore/Bridge.cpp
@@ -311,9 +311,9 @@ Leave:
     return status;
 }
 
-void DsbBridge::AddDevice(_In_ std::shared_ptr<IAdapter> adapter, _In_ std::shared_ptr<IAdapterDevice> device)
+QStatus DsbBridge::AddDevice(_In_ std::shared_ptr<IAdapter> adapter, _In_ std::shared_ptr<IAdapterDevice> device)
 {
-    CreateDevice(adapter, device);
+    return CreateDevice(adapter, device);
 }
 
 QStatus DsbBridge::CreateDevice(std::shared_ptr<IAdapter> adapter, std::shared_ptr<IAdapterDevice> device)

--- a/AllJoyn/Platform/Bridge/BridgeCore/Bridge.h
+++ b/AllJoyn/Platform/Bridge/BridgeCore/Bridge.h
@@ -38,7 +38,7 @@ namespace Bridge
         QStatus Initialize() override;
         QStatus Shutdown() override;
         void AddAdapter(_In_ std::shared_ptr<IAdapter> adapter) override;
-        void AddDevice(_In_ std::shared_ptr<IAdapter> adapter, _In_ std::shared_ptr<IAdapterDevice> device) override;
+        QStatus AddDevice(_In_ std::shared_ptr<IAdapter> adapter, _In_ std::shared_ptr<IAdapterDevice> device) override;
 
         // IAdapterSignalListener implementation
         void AdapterSignalHandler(_In_ std::shared_ptr<IAdapter> sender, _In_ std::shared_ptr<IAdapterSignal> signal, _In_opt_ intptr_t context = 0) override;

--- a/AllJoyn/Platform/Bridge/BridgeCore/BridgeDevice.cpp
+++ b/AllJoyn/Platform/Bridge/BridgeCore/BridgeDevice.cpp
@@ -43,7 +43,8 @@ BridgeDevice::BridgeDevice()
     m_uniqueIdForInterfaces(FIRST_UNIQUE_ID),
     m_deviceMain(nullptr),
     m_supportCOVSignal(false),
-    m_adapter(nullptr)
+    m_adapter(nullptr),
+    m_pControlPanel(nullptr)
 {
 }
 Bridge::BridgeDevice::~BridgeDevice()

--- a/AllJoyn/Platform/Bridge/BridgeCore/DeviceMain.h
+++ b/AllJoyn/Platform/Bridge/BridgeCore/DeviceMain.h
@@ -86,6 +86,8 @@ namespace Bridge
         std::map<std::string, DeviceSignal *> m_deviceSignals;
         uint32_t m_indexForSignal;
 
+        std::map<std::string, std::string> m_devicePropertySignatures;
+
         // alljoyn related
         alljoyn_busobject m_AJBusObject;
         alljoyn_interfacedescription m_interfaceDescription;

--- a/AllJoyn/Platform/Bridge/BridgeCore/IAdapter.h
+++ b/AllJoyn/Platform/Bridge/BridgeCore/IAdapter.h
@@ -286,7 +286,7 @@ namespace Bridge
     public:
         //
         //  Routine Description:
-        //      Status is called by the  Bridge component to get the current IO
+        //      Status is called by the Bridge component to get the current IO
         //      request status.
         //
         //  Arguments:
@@ -297,11 +297,11 @@ namespace Bridge
         //      ERROR_IO_PENDING: The request is pending.
         //      ERROR_REQUEST_ABORTED: Request was canceled, or wait was aborted.
         //
-        virtual uint32_t  Status() = 0;
+        virtual uint32_t Status() = 0;
 
         //
         //  Routine Description:
-        //      Wait is called by the  Bridge component to wait for a pending
+        //      Wait is called by the Bridge component to wait for a pending
         //      request.
         //
         //  Arguments:
@@ -311,14 +311,14 @@ namespace Bridge
         //  Return Value:
         //      ERROR_SUCCESS,
         //      ERROR_INVALID_HANDLE: Invalid request handle.
-        //      ERROR_TIMEWOUT: Timeout period has expired.
+        //      ERROR_TIMEOUT: Timeout period has expired.
         //      ERROR_REQUEST_ABORTED: Request was canceled, or wait was aborted.
         //
         virtual uint32_t Wait(uint32_t TimeoutMsec) = 0;
 
         //
         //  Routine Description:
-        //      Cancel is called by the  Bridge component to cancel a pending
+        //      Cancel is called by the Bridge component to cancel a pending
         //      request.
         //
         //  Arguments:
@@ -341,6 +341,41 @@ namespace Bridge
         //      ERROR_INVALID_HANDLE: Invalid request handle.
         //
         virtual uint32_t Release() = 0;
+    };
+
+    //
+    // IAdapterAsyncRequest interface.
+    // Description:
+    //  Extension of IAdapterIoRequest that supports continuation for improved asyncronicity.
+    //
+    class IAdapterAsyncRequest : public IAdapterIoRequest
+    {
+    public:
+        //
+        //  Routine Description:
+        //      Continue is called by the Bridge component to schedule a callback to be
+        //      invoked when the request fails or completes.
+        //
+        //      Only a single continuation may be set on a request. If the continuation is set after
+        //      the request has completed or failed perhaps because the request completed or failed
+        //      synchronously, then the continuation will still get invoked (immediately). The
+        //      continuation will NOT get invoked if request is cancelled.
+        //
+        //  Arguments:
+        //      continuationHandler - a callback invoked when the request fails or completes.
+        //
+        //    Callback Argument:
+        //      The status of the request so far; the value that would have been returned by Status()
+        //      if not for the continuation.
+        //
+        //    Callback Return Value:
+        //      The updated status of the request; the new value that will be returned by Status().
+        //
+        //  Return Value:
+        //      ERROR_SUCCESS,
+        //      ERROR_NOT_CAPABLE: Cannot set a continuation at this time.
+        //
+        virtual uint32_t Continue(std::function<uint32_t(uint32_t)> continuationHandler) = 0;
     };
 
     //

--- a/AllJoyn/Platform/Bridge/BridgeCore/IBridge.h
+++ b/AllJoyn/Platform/Bridge/BridgeCore/IBridge.h
@@ -31,6 +31,6 @@ namespace Bridge
         virtual QStatus Initialize() = 0;
         virtual QStatus Shutdown() = 0;
         virtual void AddAdapter(_In_ std::shared_ptr<IAdapter> adapter) = 0;
-        virtual void AddDevice(_In_ std::shared_ptr<IAdapter> adapter, _In_ std::shared_ptr<IAdapterDevice> device) = 0;
+        virtual QStatus AddDevice(_In_ std::shared_ptr<IAdapter> adapter, _In_ std::shared_ptr<IAdapterDevice> device) = 0;
     };
 }

--- a/AllJoyn/Platform/Bridge/BridgeNET/BridgeNET.cpp
+++ b/AllJoyn/Platform/Bridge/BridgeNET/BridgeNET.cpp
@@ -92,10 +92,6 @@ namespace BridgeNet
             {
                 auto& request = *_requestPtr;
                 status = request->Wait(INFINITE);
-                if (status == ERROR_SUCCESS)
-                {
-                    status = request->Status();
-                }
 
                 delete[] _requestPtr;
                 _requestPtr = nullptr;

--- a/AllJoyn/Platform/Bridge/BridgeNET/BridgeNET.cpp
+++ b/AllJoyn/Platform/Bridge/BridgeNET/BridgeNET.cpp
@@ -76,8 +76,8 @@ namespace BridgeNet
     ref class AdapterRequestAwaiter
     {
     public:
-        AdapterRequestAwaiter(const std::shared_ptr<IAdapterAsyncRequest>& request)
-            : _requestPtr(request ? new std::shared_ptr<IAdapterAsyncRequest>[1]{ request } : nullptr) {};
+        AdapterRequestAwaiter(std::shared_ptr<IAdapterAsyncRequest> request)
+            : _requestPtr(request ? new std::shared_ptr<IAdapterAsyncRequest>(request) : nullptr) {};
 
         Task^ WaitAsync()
         {
@@ -93,7 +93,7 @@ namespace BridgeNet
                 auto& request = *_requestPtr;
                 status = request->Wait(INFINITE);
 
-                delete[] _requestPtr;
+                delete _requestPtr;
                 _requestPtr = nullptr;
             }
 

--- a/AllJoyn/Platform/Bridge/BridgeNET/BridgeNET.cpp
+++ b/AllJoyn/Platform/Bridge/BridgeNET/BridgeNET.cpp
@@ -48,7 +48,7 @@ namespace BridgeNet
     std::shared_ptr<Bridge::IAdapterDevice> CopyDeviceInfoForAdapter(DeviceInfo^ device)
     {
         Bridge::AdapterDevice* jsDevice = new Bridge::AdapterDevice();
-    
+
         CONVERT_AND_ASSIGN_STRING_IF_NOT_NULL(jsDevice->Name, device->Name);
         CONVERT_AND_ASSIGN_STRING_IF_NOT_NULL(jsDevice->Vendor, device->Vendor);
         CONVERT_AND_ASSIGN_STRING_IF_NOT_NULL(jsDevice->Model, device->Model);
@@ -57,7 +57,7 @@ namespace BridgeNet
         CONVERT_AND_ASSIGN_STRING_IF_NOT_NULL(jsDevice->SerialNumber, device->SerialNumber);
         CONVERT_AND_ASSIGN_STRING_IF_NOT_NULL(jsDevice->Description, device->Description);
         CONVERT_AND_ASSIGN_STRING_IF_NOT_NULL(jsDevice->Props, device->Props);
-    
+
         return std::shared_ptr<Bridge::IAdapterDevice>(reinterpret_cast<Bridge::IAdapterDevice*>(jsDevice));
     }
 
@@ -67,13 +67,54 @@ namespace BridgeNet
         std::shared_ptr<IBridge> bridge = IBridge::Get();
         bridge->AddAdapter(scriptAdapter);
         bridge->Initialize();
-    
+
         return S_OK;
     }
 
-    void BridgeJs::AddDevice(DeviceInfo^ info, 
-        String^ baseTypeXml, 
-        String^ script, 
+    // Wraps a shared_ptr to an IAdapterIORequest; preserves shared_ptr lifetime management
+    // of the request object and allows waiting for the request to complete.
+    ref class AdapterRequestAwaiter
+    {
+    public:
+        AdapterRequestAwaiter(const std::shared_ptr<IAdapterAsyncRequest>& request)
+            : _requestPtr(request ? new std::shared_ptr<IAdapterAsyncRequest>[1]{ request } : nullptr) {};
+
+        Task^ WaitAsync()
+        {
+            // TODO: Use IAdapterAsyncRequest::Continue to wait without tying up a thread.
+            return Task::Run(gcnew Action(this, &AdapterRequestAwaiter::Wait));
+        }
+
+        void Wait()
+        {
+            uint32_t status = ERROR_SUCCESS;
+            if (_requestPtr)
+            {
+                auto& request = *_requestPtr;
+                status = request->Wait(INFINITE);
+                if (status == ERROR_SUCCESS)
+                {
+                    status = request->Status();
+                }
+
+                delete[] _requestPtr;
+                _requestPtr = nullptr;
+            }
+
+            if (status != ERROR_SUCCESS)
+            {
+                throw gcnew Exception(L"Adding device failed with status: " + status);
+            }
+        }
+
+    private:
+        std::shared_ptr<IAdapterAsyncRequest>* _requestPtr;
+    };
+
+    Task^ BridgeJs::AddDeviceAsync(
+        DeviceInfo^ info,
+        String^ baseTypeXml,
+        String^ script,
         String^ modulesPath)
     {
         std::shared_ptr<IJsAdapter> scriptAdapter = IJsAdapter::Get();
@@ -81,8 +122,20 @@ namespace BridgeNet
         std::string baseXml = msclr::interop::marshal_as<std::string>(baseTypeXml);
         std::string modPath = msclr::interop::marshal_as<std::string>(modulesPath);
         std::shared_ptr<IAdapterDevice> deviceToAdd = CopyDeviceInfoForAdapter(info);
-    
-        return scriptAdapter->AddDevice(deviceToAdd, baseXml, scriptStr, modPath);
+
+        std::shared_ptr<IAdapterAsyncRequest> requestPtr;
+        uint32_t status = scriptAdapter->AddDevice(deviceToAdd, baseXml, scriptStr, modPath, requestPtr);
+
+        if (status == ERROR_IO_PENDING)
+        {
+            return (gcnew AdapterRequestAwaiter(requestPtr))->WaitAsync();
+        }
+        else if (status != ERROR_SUCCESS)
+        {
+            throw gcnew Exception(L"Adding device failed with status: " + status);
+        }
+
+        return Task::Delay(0);
     }
 
     void BridgeJs::Shutdown()

--- a/AllJoyn/Platform/Bridge/BridgeNET/BridgeNET.h
+++ b/AllJoyn/Platform/Bridge/BridgeNET/BridgeNET.h
@@ -17,17 +17,19 @@
 
 #include "DeviceInfo.h"
 using namespace System;
+using namespace System::Threading::Tasks;
 
 namespace BridgeNet 
 {
-	public ref class BridgeJs
-	{
+    public ref class BridgeJs
+    {
     public:
         Int32 Initialize();
-        void AddDevice(DeviceInfo^ info, 
+        Task^ AddDeviceAsync(
+            DeviceInfo^ info, 
             String^ baseTypeXml, 
             String^ script,
             String^ modulesPath);
         void Shutdown();
-	};
+    };
 }

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLib/IJsAdapter.h
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLib/IJsAdapter.h
@@ -31,7 +31,13 @@ class IJsAdapter : public Bridge::IAdapter
 public:
     static std::shared_ptr<IJsAdapter> Get();
 
-    virtual void AddDevice(_In_ std::shared_ptr<Bridge::IAdapterDevice>& device, _In_ const std::string& baseTypeXml, _In_ const std::string& jsScript, _In_ const std::string& jsModulesPath) = 0;
+    virtual uint32_t AddDevice(
+        _In_ std::shared_ptr<Bridge::IAdapterDevice> device,
+        _In_ const std::string& baseTypeXml,
+        _In_ const std::string& jsScript,
+        _In_ const std::string& jsModulesPath,
+        _Out_opt_ std::shared_ptr<Bridge::IAdapterAsyncRequest>& requestPtr) = 0;
+
     virtual void SetAdapterError(_In_ std::shared_ptr<IJsAdapterError>& adaptErr) = 0;
 };
 

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLib/JsAdapter.cpp
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLib/JsAdapter.cpp
@@ -20,21 +20,22 @@
 #include "AdapterDevice.h"
 #include "ScriptHost.h"
 #include "JsAdapter.h"
+#include "JsAdapterRequest.h"
 
 using namespace Bridge;
 
 namespace AdapterLib
 {
-	std::shared_ptr<JsAdapter> JsAdapter::g_TheOneOnlyInstance = nullptr;
+    std::shared_ptr<JsAdapter> JsAdapter::g_TheOneOnlyInstance = nullptr;
 
-	std::shared_ptr<JsAdapter> JsAdapter::SingleInstance()
-	{
-		if (g_TheOneOnlyInstance == nullptr)
-		{
-			g_TheOneOnlyInstance = std::shared_ptr<JsAdapter>(new JsAdapter());
-		}
-		return g_TheOneOnlyInstance;
-	}
+    std::shared_ptr<JsAdapter> JsAdapter::SingleInstance()
+    {
+        if (g_TheOneOnlyInstance == nullptr)
+        {
+            g_TheOneOnlyInstance = std::shared_ptr<JsAdapter>(new JsAdapter());
+        }
+        return g_TheOneOnlyInstance;
+    }
 
     /*static*/ std::shared_ptr<IJsAdapter> IJsAdapter::Get()
     {
@@ -49,8 +50,8 @@ namespace AdapterLib
         this->adapterName = "Javascript Device System Bridge";
         // the adapter prefix must be something like "com.mycompany" (only alpha num and dots)
         // it is used by the Device System Bridge as root string for all services and interfaces it exposes
-		this->exposedAdapterPrefix = "com.";
-		this->exposedAdapterPrefix += this->vendor.c_str();
+        this->exposedAdapterPrefix = "com.";
+        this->exposedAdapterPrefix += this->vendor.c_str();
         this->exposedApplicationGuid = APPLICATION_GUID;
         this->exposedApplicationName = "Javascript Device System Bridge";
 
@@ -93,35 +94,52 @@ namespace AdapterLib
 
     // Create a new IAdapterDevice for the Alljoyn interface described by the given xml, and associate
     // it with the given JavaScript and initialize the Javascript with the given context object.
-    void JsAdapter::AddDevice(_In_ std::shared_ptr<IAdapterDevice>& device, _In_ const std::string& baseTypeXml, _In_ const std::string& jsScript, _In_ const std::string& jsModulesPath)
+    uint32_t JsAdapter::AddDevice(
+        _In_ std::shared_ptr<IAdapterDevice> device,
+        _In_ const std::string& baseTypeXml,
+        _In_ const std::string& jsScript,
+        _In_ const std::string& jsModulesPath,
+        _Out_opt_ std::shared_ptr<IAdapterAsyncRequest>& requestPtr)
     {
-        try
+        ScriptHost* host = new ScriptHost();
+
+        device->BaseTypeXML(baseTypeXml);
+
+        // Set the host context on the device, required when it processes methods, events etc.
+        device->HostContext(reinterpret_cast<intptr_t>(reinterpret_cast<void*>(host)));
+
+        auto adapterRequest = std::make_shared<JsAdapterRequest>();
+        requestPtr = adapterRequest;
+        host->InitializeHost(device, jsScript, jsModulesPath, [=](uint32_t status)
         {
-            ScriptHost* host = new ScriptHost();
+            if (status == ERROR_SUCCESS)
+            {
+                std::shared_ptr<IAdapter> adapter = std::dynamic_pointer_cast<IAdapter>(g_TheOneOnlyInstance);
+                std::shared_ptr<IBridge> bridge = IBridge::Get();
+                QStatus bridgeStatus = bridge->AddDevice(adapter, device);
+                if (bridgeStatus != ER_OK)
+                {
+                    std::cerr << "JsAdapter could not add device. Bridge returned status: " << bridgeStatus << std::endl;
+                    status = ERROR_GEN_FAILURE;
+                }
+            }
+            else
+            {
+                std::cerr << "JsAdapter could not add device. Initialization returned status: " << status << std::endl;
+            }
 
-            device->BaseTypeXML(baseTypeXml);
-            host->InitializeHost(device.get(), jsScript, jsModulesPath);
+            adapterRequest->SetStatus(status);
+        });
 
-            // Set the host context on the device, reuqired when it processes methods, events etc.
-            device->HostContext(reinterpret_cast<intptr_t>(reinterpret_cast<void*>(host)));
-
-            // TODO: This appears to be leaking abstraction, should only use IBridge
-            std::shared_ptr<IAdapter> adapt(dynamic_cast<IAdapter*>(this));
-            std::shared_ptr<IBridge> bridge = IBridge::Get();
-            bridge->AddDevice(adapt, device);
-        }
-        catch (...)
-        {
-            std::cerr << "JsAdapter could not add device" << std::endl;
-        }
+        return adapterRequest->Status();
     }
 
     _Use_decl_annotations_
     uint32_t
     JsAdapter::EnumDevices(
         ENUM_DEVICES_OPTIONS /*Options*/,
-		AdapterDeviceVector& /*DeviceListPtr*/,
-		std::shared_ptr<IAdapterIoRequest>& /*RequestPtr*/
+        AdapterDeviceVector& /*DeviceListPtr*/,
+        std::shared_ptr<IAdapterIoRequest>& /*RequestPtr*/
         )
     {
         return ERROR_SUCCESS;
@@ -131,8 +149,8 @@ namespace AdapterLib
     _Use_decl_annotations_
     uint32_t
     JsAdapter::GetProperty(
-		std::shared_ptr<IAdapterProperty>& /*Property*/,
-		std::shared_ptr<IAdapterIoRequest>& /*RequestPtr*/
+        std::shared_ptr<IAdapterProperty>& /*Property*/,
+        std::shared_ptr<IAdapterIoRequest>& /*RequestPtr*/
         )
     {
         return ERROR_SUCCESS;
@@ -142,8 +160,8 @@ namespace AdapterLib
     _Use_decl_annotations_
     uint32_t
     JsAdapter::SetProperty(
-		std::shared_ptr<IAdapterProperty> /*Property*/,
-		std::shared_ptr<IAdapterIoRequest>& /*RequestPtr*/
+        std::shared_ptr<IAdapterProperty> /*Property*/,
+        std::shared_ptr<IAdapterIoRequest>& /*RequestPtr*/
         )
     {
         return ERROR_SUCCESS;
@@ -153,10 +171,10 @@ namespace AdapterLib
     uint32_t
     JsAdapter::GetPropertyValue(
         _In_ std::shared_ptr<IAdapterDevice> device,
-		std::shared_ptr<IAdapterProperty> Property,
-		std::string AttributeName,
-		std::shared_ptr<IAdapterValue>& ValuePtr,
-		std::shared_ptr<IAdapterIoRequest>& RequestPtr
+        std::shared_ptr<IAdapterProperty> Property,
+        std::string AttributeName,
+        std::shared_ptr<IAdapterValue>& ValuePtr,
+        std::shared_ptr<IAdapterIoRequest>& RequestPtr
         )
     {
         uint32_t status = ERROR_SUCCESS;
@@ -174,44 +192,48 @@ namespace AdapterLib
             return static_cast<uint32_t>(ER_BAD_ARG_1);
         }
 
-        try
+        // Run the script to get that property. Script function is "getPROPNAME" where PROPNAME is the name of the property
+        // e.g. getBrightness
+
+        AdapterValueVector paramsIn;
+        std::string name("get");
+        name += tempProperty->Name();
+        ScriptHost* host = reinterpret_cast<ScriptHost*>((void*)device->HostContext());
+
+        auto adapterRequest = std::make_shared<JsAdapterRequest>();
+        std::shared_ptr<IAdapterValue> resultValue = ValuePtr;
+        RequestPtr = adapterRequest;
+        host->CallScriptFunction(name, paramsIn, false, [=](uint32_t status, AdapterValueVector outParams)
         {
-            // Run the script to get that property. Script function is "getPROPNAME" where PROPNAME is the name of the property
-            // e.g. getBrightness
-
-            AdapterValueVector paramsIn;
-            AdapterValueVector paramsOut;
-            std::string name("get");
-            name += tempProperty->Name();
-            ScriptHost* host = reinterpret_cast<ScriptHost*>((void*)device->HostContext());
-
-            host->CallScriptFunction(name, paramsIn, paramsOut);
-            if (paramsOut.size() > 0)
+            if (status == ERROR_SUCCESS)
             {
-                // Set ValuePtr to the result value
-                ValuePtr = paramsOut.at(0);
+                if (outParams.size() > 0)
+                {
+                    *resultValue = *outParams.at(0);
+                }
+                else
+                {
+                    status = ERROR_GEN_FAILURE;
+                }
             }
             else
             {
-                status = static_cast<uint32_t>(ER_FAIL);
+                std::cerr << "GetPropertyValue failed on adapter" << std::endl;
             }
-        }
-        catch (...)
-        {
-            std::cerr << "GetPropertyValue failed on adapter" << std::endl;
-            status = static_cast<uint32_t>(ER_FAIL);
-        }
 
-        return status;
+            adapterRequest->SetStatus(status);
+        });
+
+        return adapterRequest->Status();
     }
 
     _Use_decl_annotations_
     uint32_t
     JsAdapter::SetPropertyValue(
-		std::shared_ptr<IAdapterDevice> device,
-		std::shared_ptr<IAdapterProperty> Property,
-		std::shared_ptr<IAdapterValue> Value,
-		std::shared_ptr<IAdapterIoRequest>& RequestPtr
+        std::shared_ptr<IAdapterDevice> device,
+        std::shared_ptr<IAdapterProperty> Property,
+        std::shared_ptr<IAdapterValue> Value,
+        std::shared_ptr<IAdapterIoRequest>& RequestPtr
         )
     {
         uint32_t status = ERROR_SUCCESS;
@@ -241,64 +263,70 @@ namespace AdapterLib
             }
         }
 
-        try
+        // Run the script to get that property. Script function is "setPROPNAME" where PROPNAME is the name of the property
+        // e.g. getBrightness
+
+        AdapterValueVector paramsIn;
+        AdapterValueVector paramsOut;
+        std::string name("set");
+        name += tempProperty->Name();
+        ScriptHost* host = reinterpret_cast<ScriptHost*>((void*)device->HostContext());
+        std::shared_ptr<IAdapterValue> sharedVal(dynamic_cast<IAdapterValue*>(tempValue));
+        paramsIn.push_back(sharedVal);
+
+        auto adapterRequest = std::make_shared<JsAdapterRequest>();
+        RequestPtr = adapterRequest;
+        host->CallScriptFunction(name, paramsIn, false, [=](uint32_t status, AdapterValueVector outParams)
         {
-            // Run the script to get that property. Script function is "setPROPNAME" where PROPNAME is the name of the property
-            // e.g. getBrightness
+            if (status != ERROR_SUCCESS)
+            {
+                std::cerr << "GetPropertyValue failed on adapter" << std::endl;
+            }
 
-            AdapterValueVector paramsIn;
-            AdapterValueVector paramsOut;
-            std::string name("set");
-            name += tempProperty->Name();
-            ScriptHost* host = reinterpret_cast<ScriptHost*>((void*)device->HostContext());
-            std::shared_ptr<IAdapterValue> sharedVal(dynamic_cast<IAdapterValue*>(tempValue));
-            paramsIn.push_back(sharedVal);
+            adapterRequest->SetStatus(status);
+        });
 
-            host->CallScriptFunction(name, paramsIn, paramsOut);
-            status = ERROR_SUCCESS;
-        }
-        catch (...)
-        {
-            std::cerr << "GetPropertyValue failed on adapter" << std::endl;
-            status = static_cast<uint32_t>(ER_FAIL);
-        }
-
-        return status;
+        return adapterRequest->Status();
     }
 
     _Use_decl_annotations_
     uint32_t
     JsAdapter::CallMethod(
-		std::shared_ptr<IAdapterDevice> device,
-		std::shared_ptr<IAdapterMethod>& method,
-		std::shared_ptr<IAdapterIoRequest>& /*requestPtr*/
+        std::shared_ptr<IAdapterDevice> device,
+        std::shared_ptr<IAdapterMethod>& method,
+        std::shared_ptr<IAdapterIoRequest>& requestPtr
         )
     {
         uint32_t status = 0;
 
         // Call the script function
-        try
-        {
-            ScriptHost* host = reinterpret_cast<ScriptHost*>((void*)device->HostContext());
+        ScriptHost* host = reinterpret_cast<ScriptHost*>((void*)device->HostContext());
 
-            host->CallScriptFunction(method->Name(), method->InputParams(), method->OutputParams());
-            status = ERROR_SUCCESS;
-        }
-        catch (...)
+        auto adapterRequest = std::make_shared<JsAdapterRequest>();
+        requestPtr = adapterRequest;
+        host->CallScriptFunction(method->Name(), method->InputParams(), false, [=](uint32_t status, AdapterValueVector outParams)
         {
-            std::cerr << "CallMethod failed on adapter" << std::endl;
-            status = static_cast<uint32_t>(ER_FAIL);
-        }
+            if (status == ERROR_SUCCESS)
+            {
+                method->OutputParams() = outParams;
+            }
+            else
+            {
+                std::cerr << "CallMethod failed on adapter" << std::endl;
+            }
 
-        return status;
+            adapterRequest->SetStatus(status);
+        });
+
+        return adapterRequest->Status();
     }
 
     _Use_decl_annotations_
     uint32_t
     JsAdapter::RegisterSignalListener(
-		std::shared_ptr<IAdapterSignal> Signal,
-		std::shared_ptr<IAdapterSignalListener> Listener,
-		intptr_t ListenerContext
+        std::shared_ptr<IAdapterSignal> Signal,
+        std::shared_ptr<IAdapterSignalListener> Listener,
+        intptr_t ListenerContext
         )
     {
         if (Signal == nullptr || Listener == nullptr)
@@ -321,8 +349,8 @@ namespace AdapterLib
     _Use_decl_annotations_
     uint32_t
     JsAdapter::UnregisterSignalListener(
-		std::shared_ptr<IAdapterSignal> /*Signal*/,
-		std::shared_ptr<IAdapterSignalListener> /*Listener*/
+        std::shared_ptr<IAdapterSignal> /*Signal*/,
+        std::shared_ptr<IAdapterSignalListener> /*Listener*/
         )
     {
         return ERROR_SUCCESS;
@@ -331,7 +359,7 @@ namespace AdapterLib
     _Use_decl_annotations_
     uint32_t
     JsAdapter::NotifySignalListener(
-		std::shared_ptr<IAdapterSignal> signal
+        std::shared_ptr<IAdapterSignal> signal
         )
     {
         if (signal == nullptr)
@@ -350,9 +378,9 @@ namespace AdapterLib
         for (auto iter = handlers.begin(); iter != handlers.end(); ++iter)
         {
             IAdapterSignalListener* listener = iter->second.Listener.get();
-			intptr_t listenerContext = iter->second.Context;
-			std::shared_ptr<IAdapter> adapt(dynamic_cast<IAdapter*>(this));
-			listener->AdapterSignalHandler(adapt, signal, listenerContext);
+            intptr_t listenerContext = iter->second.Context;
+            std::shared_ptr<IAdapter> adapt(dynamic_cast<IAdapter*>(this));
+            listener->AdapterSignalHandler(adapt, signal, listenerContext);
         }
 
         return ERROR_SUCCESS;
@@ -361,7 +389,7 @@ namespace AdapterLib
     _Use_decl_annotations_
     uint32_t
     JsAdapter::NotifyDeviceArrival(
-		std::shared_ptr<IAdapterDevice> Device
+        std::shared_ptr<IAdapterDevice> Device
         )
     {
         if (Device == nullptr)
@@ -369,7 +397,7 @@ namespace AdapterLib
             return static_cast<uint32_t>(ER_BAD_ARG_1);
         }
 
-		std::shared_ptr<IAdapterSignal> deviceArrivalSignal = this->signals.at(DEVICE_ARRIVAL_SIGNAL_INDEX);
+        std::shared_ptr<IAdapterSignal> deviceArrivalSignal = this->signals.at(DEVICE_ARRIVAL_SIGNAL_INDEX);
         deviceArrivalSignal->Params().at(DEVICE_ARRIVAL_SIGNAL_PARAM_INDEX)->Data() = Device;
         this->NotifySignalListener(deviceArrivalSignal);
 
@@ -379,7 +407,7 @@ namespace AdapterLib
     _Use_decl_annotations_
     uint32_t
     JsAdapter::NotifyDeviceRemoval(
-		std::shared_ptr<IAdapterDevice> Device
+        std::shared_ptr<IAdapterDevice> Device
         )
     {
         if (Device == nullptr)
@@ -387,7 +415,7 @@ namespace AdapterLib
             return static_cast<uint32_t>(ER_BAD_ARG_1);
         }
 
-		std::shared_ptr<IAdapterSignal> deviceRemovalSignal = this->signals.at(DEVICE_REMOVAL_SIGNAL_INDEX);
+        std::shared_ptr<IAdapterSignal> deviceRemovalSignal = this->signals.at(DEVICE_REMOVAL_SIGNAL_INDEX);
         deviceRemovalSignal->Params().at(DEVICE_REMOVAL_SIGNAL_PARAM_INDEX)->Data() = Device;
         this->NotifySignalListener(deviceRemovalSignal);
 
@@ -400,14 +428,14 @@ namespace AdapterLib
         try
         {
             // Device Arrival Signal
-			std::shared_ptr<AdapterSignal> deviceArrivalSignal(new AdapterSignal(Constants::DEVICE_ARRIVAL_SIGNAL()));
-			std::shared_ptr<IAdapterValue> arrivalValue(new AdapterValue(Constants::DEVICE_ARRIVAL__DEVICE_HANDLE(), nullptr));
+            std::shared_ptr<AdapterSignal> deviceArrivalSignal(new AdapterSignal(Constants::DEVICE_ARRIVAL_SIGNAL()));
+            std::shared_ptr<IAdapterValue> arrivalValue(new AdapterValue(Constants::DEVICE_ARRIVAL__DEVICE_HANDLE(), nullptr));
             deviceArrivalSignal->AddParameter(arrivalValue);
 
             // Device Removal Signal
-			std::shared_ptr<AdapterSignal> deviceRemovalSignal(new AdapterSignal(Constants::DEVICE_REMOVAL_SIGNAL()));
-			std::shared_ptr<IAdapterValue> removalValue(new AdapterValue(Constants::DEVICE_REMOVAL__DEVICE_HANDLE(), nullptr));
-			deviceRemovalSignal->AddParameter(removalValue);
+            std::shared_ptr<AdapterSignal> deviceRemovalSignal(new AdapterSignal(Constants::DEVICE_REMOVAL_SIGNAL()));
+            std::shared_ptr<IAdapterValue> removalValue(new AdapterValue(Constants::DEVICE_REMOVAL__DEVICE_HANDLE(), nullptr));
+            deviceRemovalSignal->AddParameter(removalValue);
 
             // Add Signals to Adapter Signals
             this->signals.push_back(deviceArrivalSignal);
@@ -465,10 +493,10 @@ namespace AdapterLib
     //    return deviceVector;
     //}
 
-	void JsAdapter::SetAdapterError(std::shared_ptr<IJsAdapterError>& adaptErr)
-	{
-		this->adapterError = adaptErr;
-	}
+    void JsAdapter::SetAdapterError(std::shared_ptr<IJsAdapterError>& adaptErr)
+    {
+        this->adapterError = adaptErr;
+    }
 
 } // namespace AdapterLib
 

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLib/JsAdapter.cpp
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLib/JsAdapter.cpp
@@ -184,10 +184,8 @@ namespace AdapterLib
             RequestPtr = nullptr;
         }
         // sanity check
-        AdapterProperty* tempProperty = dynamic_cast<AdapterProperty*>(Property.get());
         if (ValuePtr == nullptr ||
-            tempProperty == nullptr ||
-            tempProperty->Attributes().empty())
+            Property == nullptr)
         {
             return static_cast<uint32_t>(ER_BAD_ARG_1);
         }
@@ -228,22 +226,19 @@ namespace AdapterLib
         }
 
         // sanity check
-        AdapterProperty* tempProperty = dynamic_cast<AdapterProperty*>(Property.get());
-        AdapterValue* tempValue = dynamic_cast<AdapterValue*>(Value.get());
-        if (tempValue == nullptr ||
-            tempProperty == nullptr ||
-            tempProperty->Attributes().empty())
+        if (Value == nullptr ||
+            Property == nullptr)
         {
             return static_cast<uint32_t>(ER_BAD_ARG_1);
         }
 
         // find corresponding attribute
-        for (auto attribute : tempProperty->Attributes())
+        for (auto attribute : Property->Attributes())
         {
             if (attribute->Value() != nullptr &&
-                attribute->Value()->Name() == tempValue->Name())
+                attribute->Value()->Name() == Value->Name())
             {
-                attribute->Value()->Data() = tempValue->Data();
+                attribute->Value()->Data() = Value->Data();
                 return ERROR_SUCCESS;
             }
         }
@@ -253,12 +248,11 @@ namespace AdapterLib
         AdapterValueVector paramsIn;
         AdapterValueVector paramsOut;
         ScriptHost* host = reinterpret_cast<ScriptHost*>((void*)device->HostContext());
-        std::shared_ptr<IAdapterValue> sharedVal(dynamic_cast<IAdapterValue*>(tempValue));
-        paramsIn.push_back(sharedVal);
+        paramsIn.push_back(Value);
 
         auto adapterRequest = std::make_shared<JsAdapterRequest>();
         RequestPtr = adapterRequest;
-        host->InvokePropertySetter(tempProperty->Name(), Value, [=](uint32_t status)
+        host->InvokePropertySetter(Property->Name(), Value, [=](uint32_t status)
         {
             if (status != ERROR_SUCCESS)
             {

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLib/JsAdapter.h
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLib/JsAdapter.h
@@ -35,7 +35,7 @@ namespace AdapterLib
         JsAdapter();
         virtual ~JsAdapter();
 
-		static std::shared_ptr<JsAdapter> SingleInstance();
+        static std::shared_ptr<JsAdapter> SingleInstance();
 
         //
         // Adapter information
@@ -79,32 +79,37 @@ namespace AdapterLib
             _Out_opt_ std::shared_ptr<IAdapterIoRequest>& requestPtr
             ) override;
         uint32_t SetPropertyValue(
-			_In_ std::shared_ptr<IAdapterDevice> device,
-			_In_ std::shared_ptr<IAdapterProperty> aProperty,
-			_In_ std::shared_ptr<IAdapterValue> value,
-			_Out_opt_ std::shared_ptr<IAdapterIoRequest>& requestPtr
-			) override;
+            _In_ std::shared_ptr<IAdapterDevice> device,
+            _In_ std::shared_ptr<IAdapterProperty> aProperty,
+            _In_ std::shared_ptr<IAdapterValue> value,
+            _Out_opt_ std::shared_ptr<IAdapterIoRequest>& requestPtr
+            ) override;
 
         uint32_t CallMethod(
-			_In_ std::shared_ptr<IAdapterDevice> device,
-			_Inout_ std::shared_ptr<IAdapterMethod>& method,
-			_Out_opt_ std::shared_ptr<IAdapterIoRequest>& requestPtr
-			) override;
+            _In_ std::shared_ptr<IAdapterDevice> device,
+            _Inout_ std::shared_ptr<IAdapterMethod>& method,
+            _Out_opt_ std::shared_ptr<IAdapterIoRequest>& requestPtr
+            ) override;
 
         uint32_t RegisterSignalListener(
-			_In_ std::shared_ptr<IAdapterSignal> signal,
-			_In_ std::shared_ptr<IAdapterSignalListener> listener,
-			_In_opt_ intptr_t listenerContext = 0
-			) override;
+            _In_ std::shared_ptr<IAdapterSignal> signal,
+            _In_ std::shared_ptr<IAdapterSignalListener> listener,
+            _In_opt_ intptr_t listenerContext = 0
+            ) override;
         uint32_t UnregisterSignalListener(
-			_In_ std::shared_ptr<IAdapterSignal> signal,
-			_In_ std::shared_ptr<IAdapterSignalListener> listener
-			) override;
+            _In_ std::shared_ptr<IAdapterSignal> signal,
+            _In_ std::shared_ptr<IAdapterSignalListener> listener
+            ) override;
 
         // Load the given javascript and associate it with the given device by calling 'initDevice' function
-        void AddDevice(_In_ std::shared_ptr<IAdapterDevice>& device, _In_ const std::string& baseTypeXml, _In_ const std::string& jsScript, _In_ const std::string& jsModulesPath) override;
+        uint32_t AddDevice(
+            _In_ std::shared_ptr<IAdapterDevice> device,
+            _In_ const std::string& baseTypeXml,
+            _In_ const std::string& jsScript,
+            _In_ const std::string& jsModulesPath,
+            _Out_opt_ std::shared_ptr<IAdapterAsyncRequest>& requestPtr) override;
 
-		void SetAdapterError(std::shared_ptr<IJsAdapterError>& adaptErr) override;
+        void SetAdapterError(std::shared_ptr<IJsAdapterError>& adaptErr) override;
 
     protected:
         //
@@ -161,9 +166,9 @@ namespace AdapterLib
     private:
         void CreateSignals();
 
-		static std::shared_ptr<JsAdapter> g_TheOneOnlyInstance;
-		
-		std::string vendor;
+        static std::shared_ptr<JsAdapter> g_TheOneOnlyInstance;
+        
+        std::string vendor;
         std::string adapterName;
         std::string version;
         // the prefix for AllJoyn service should be something like
@@ -190,9 +195,9 @@ namespace AdapterLib
         struct SIGNAL_LISTENER_ENTRY
         {
             SIGNAL_LISTENER_ENTRY(
-				std::shared_ptr<IAdapterSignal> SignalToRegisterTo,
-				std::shared_ptr<IAdapterSignalListener> ListenerObject,
-				intptr_t ListenerContext
+                std::shared_ptr<IAdapterSignal> SignalToRegisterTo,
+                std::shared_ptr<IAdapterSignalListener> ListenerObject,
+                intptr_t ListenerContext
                 )
                 : Signal(SignalToRegisterTo)
                 , Listener(ListenerObject)
@@ -201,16 +206,16 @@ namespace AdapterLib
             }
 
             // The  signal object
-			std::shared_ptr<IAdapterSignal> Signal;
+            std::shared_ptr<IAdapterSignal> Signal;
 
             // The listener object
-			std::shared_ptr<IAdapterSignalListener> Listener;
+            std::shared_ptr<IAdapterSignalListener> Listener;
 
             //
             // The listener context that will be
             // passed to the signal handler
             //
-			intptr_t Context;
+            intptr_t Context;
         };
 
         // A map of signal handle (object's hash code) and related listener entry
@@ -222,6 +227,6 @@ namespace AdapterLib
         static const int DEVICE_REMOVAL_SIGNAL_INDEX = 1;
         static const int DEVICE_REMOVAL_SIGNAL_PARAM_INDEX = 0;
 
-		std::shared_ptr<IJsAdapterError> adapterError;
+        std::shared_ptr<IJsAdapterError> adapterError;
     };
 } // namespace AdapterLib

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLib/JsAdapterRequest.cpp
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLib/JsAdapterRequest.cpp
@@ -76,9 +76,7 @@ namespace AdapterLib
         bool completed = _condition.wait_for(
             lock, std::chrono::milliseconds(timeoutMsec), [&]() { return _status != ERROR_IO_PENDING; });
 
-        // Note after receiving an ERROR_SUCCESS result from a wait, callers must still check Status()
-        // to get the actual status of the overall request.
-        return completed ? ERROR_SUCCESS : ERROR_TIMEOUT;
+        return completed ? _status : ERROR_TIMEOUT;
     }
 
     uint32_t JsAdapterRequest::Cancel()

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLib/JsAdapterRequest.cpp
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLib/JsAdapterRequest.cpp
@@ -1,0 +1,108 @@
+//
+// Copyright (c) 2015, Microsoft Corporation
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+// IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+
+#include "pch.h"
+#include "BridgeCommon.h"
+#include "JsAdapterRequest.h"
+
+using namespace Bridge;
+
+namespace AdapterLib
+{
+
+    JsAdapterRequest::JsAdapterRequest() :
+        _status(ERROR_IO_PENDING)
+    {
+    }
+
+    void JsAdapterRequest::SetStatus(uint32_t status)
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        // If status is being changed from pending to not pending and a completion handler was set,
+        // invoke it then use the updated status instead.
+        if (_continuationHandler && _status == ERROR_IO_PENDING && status != _status)
+        {
+            status = _continuationHandler(status);
+        }
+
+        _status = status;
+        _condition.notify_all();
+    }
+
+    uint32_t JsAdapterRequest::Continue(std::function<uint32_t(uint32_t)> continuationHandler)
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (_continuationHandler)
+        {
+            return ERROR_NOT_CAPABLE;
+        }
+
+        _continuationHandler = continuationHandler;
+
+        // If the status is not pending and not aborted, invoke the continuation handler immediately.
+        if (_continuationHandler && _status != ERROR_IO_PENDING && _status != ERROR_REQUEST_ABORTED)
+        {
+            _status = _continuationHandler(_status);
+        }
+
+        return ERROR_SUCCESS;
+    }
+
+    uint32_t JsAdapterRequest::Status()
+    {
+        return _status;
+    }
+
+    uint32_t JsAdapterRequest::Wait(uint32_t timeoutMsec)
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+
+        // Wait until the status is anything other than ERROR_IO_PENDING (or the timeout elapses).
+        bool completed = _condition.wait_for(
+            lock, std::chrono::milliseconds(timeoutMsec), [&]() { return _status != ERROR_IO_PENDING; });
+
+        // Note after receiving an ERROR_SUCCESS result from a wait, callers must still check Status()
+        // to get the actual status of the overall request.
+        return completed ? ERROR_SUCCESS : ERROR_TIMEOUT;
+    }
+
+    uint32_t JsAdapterRequest::Cancel()
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (_status == ERROR_IO_PENDING)
+        {
+            // This unblocks any threads stuck in Wait(). The actual request operation will not be aborted,
+            // though any results from it will be ignored. The continuation (if set) is NOT invoked.
+            _status = ERROR_REQUEST_ABORTED;
+            _condition.notify_all();
+            return ERROR_SUCCESS;
+        }
+        else
+        {
+            // The request is already completed (or aborted).
+            return ERROR_NOT_CAPABLE;
+        }
+    }
+
+    uint32_t JsAdapterRequest::Release()
+    {
+        this->Cancel();
+        return ERROR_SUCCESS;
+    }
+}

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLib/JsAdapterRequest.h
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLib/JsAdapterRequest.h
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2015, Microsoft Corporation
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+// IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+
+#pragma once
+
+#include <mutex>
+#include "IAdapter.h"
+
+using namespace Bridge;
+
+namespace AdapterLib
+{
+    // Tracks the status of an async request to a JsAdapter, allowing callers to set a continuation handler
+    // and/or wait for completion.
+    class JsAdapterRequest : public IAdapterAsyncRequest
+    {
+    public:
+        JsAdapterRequest();
+
+        // When status is set to anything other than ERROR_IO_PENDING, the continuation (if set) is invoked
+        // and any outstanding calls to Wait() are unblocked.
+        void SetStatus(uint32_t status);
+
+        // IAdapterAsyncRequest methods
+
+        uint32_t Continue(std::function<uint32_t(uint32_t)> continuationHandler) override;
+        uint32_t Status() override;
+        uint32_t Wait(uint32_t timeoutMsec) override;
+        uint32_t Cancel() override;
+        uint32_t Release() override;
+
+    private:
+        uint32_t _status;
+        std::mutex _mutex;
+        std::condition_variable _condition;
+        std::function<uint32_t(uint32_t)> _continuationHandler;
+    };
+}

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLib/ScriptAdapterLib.vcxproj
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLib/ScriptAdapterLib.vcxproj
@@ -214,12 +214,14 @@
     <ClInclude Include="Deps\inc\jx_result.h" />
     <ClInclude Include="IJsAdapter.h" />
     <ClInclude Include="JsAdapter.h" />
+    <ClInclude Include="JsAdapterRequest.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="ScriptHost.h" />
     <ClInclude Include="WorkItemDispatcher.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="JsAdapter.cpp" />
+    <ClCompile Include="JsAdapterRequest.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Create</PrecompiledHeader>

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLib/ScriptAdapterLib.vcxproj.filters
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLib/ScriptAdapterLib.vcxproj.filters
@@ -41,12 +41,18 @@
     <ClInclude Include="IJsAdapter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="JsAdapterRequest.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="JsAdapter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="JsAdapterRequest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLib/ScriptHost.h
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLib/ScriptHost.h
@@ -14,7 +14,7 @@
 // IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 //
 #pragma once
-#include <map>
+#include <unordered_map>
 #include "WorkItemDispatcher.h"
 
 namespace ScriptHostConstants
@@ -22,6 +22,7 @@ namespace ScriptHostConstants
     const char DeviceObjectName[] = "device";
     const char InitializationFunctionName[] = "initDevice";
     const char RaiseSignalName[] = "raiseSignal";
+    const char ReportResultName[] = "reportResult";
     const char Name[] = "name";
     const char Props[] = "props";
     const char Vendor[] = "vendor";
@@ -31,6 +32,7 @@ namespace ScriptHostConstants
     const char SerialNumber[] = "serialNumber";
     const char Description[] = "description";
     const char This[] = "This";
+    const char Then[] = "then";
     const char ContextName[] = "_adapterDeviceCtx";
 };
 
@@ -57,12 +59,15 @@ public:
 
     // Initializes this host instance.
     // This starts a new JxCore instance on a dedicated thread.
-    void InitializeHost(Bridge::IAdapterDevice* pDevice, const std::string& script, const std::string& modulesPath)
+    void InitializeHost(
+        std::shared_ptr<Bridge::IAdapterDevice> device,
+        const std::string& script,
+        const std::string& modulesPath,
+        std::function<void(uint32_t)> callback)
     {
         _dispatcher.Initialize();
 
-        _dispatcher.DispatchAndWait(
-        [&]()
+        _dispatcher.Dispatch([=]()
         {
             JX_InitializeOnce(".");
             JX_InitializeNewEngine();
@@ -70,14 +75,27 @@ public:
             JX_StartEngine();
 
             // Register global object
-            RegisterDeviceObject(pDevice);
+            RegisterDeviceObject(device.get());
             JX_Loop();
 
             // Call script function initDevice
             JXValue result;
             std::vector<JXValue> params;
             params.emplace_back(_deviceObject);
-            InternalCallScriptFunction(&result, ScriptHostConstants::InitializationFunctionName, params);
+            if (InternalCallScriptFunction(&result, ScriptHostConstants::InitializationFunctionName, params))
+            {
+                GetAsyncJxResult(&result,
+                    [=](bool success, JXResult* asyncResult)
+                    {
+                        callback(success ? ERROR_SUCCESS : ERROR_GEN_FAILURE);
+                    });
+            }
+            else
+            {
+                callback(ERROR_GEN_FAILURE);
+            }
+
+            JX_Free(&result);
         });
     }
 
@@ -87,15 +105,17 @@ public:
     // should be added to the "global" object e.g.
     //          var myFunc = function () { ...... }
     //          globals.myFunc = myFunc;
-    // For simplicity, this method waits for the call to complete, since the callers expect script hosts to be synchronous. 
+    // This dispatches the call to the JxCore instance and returns status and results asynchronously via the callback.
     // In future, this can be moved to return results asynchronously.
-    // This dispatches the call to the JxCore instance and waits for it to complete.
     // The "insertDeviceObject" parameter, if true, adds the "device" object as the first parameter. The device object is the projected 
     // version of the IAdapterDevice used to start this script host instance.
-
-    void CallScriptFunction(const std::string& name, const Bridge::AdapterValueVector& inParams, Bridge::AdapterValueVector& outParams, bool insertDeviceObject = false)
+    void CallScriptFunction(
+        const std::string& name,
+        const Bridge::AdapterValueVector& inParams,
+        bool insertDeviceObject,
+        std::function<void(uint32_t,Bridge::AdapterValueVector&)> callback)
     {
-        _dispatcher.DispatchAndWait([&]()
+        _dispatcher.Dispatch([=]()
         {
             // Convert the input parameters
             std::vector<JXValue> jxInputParams;
@@ -109,10 +129,29 @@ public:
             
             // Call the script function
             JXValue result;
-            InternalCallScriptFunction(&result, name, jxInputParams);
+            if (InternalCallScriptFunction(&result, name, jxInputParams))
+            {
+                GetAsyncJxResult(&result,
+                    [=](bool success, JXResult* asyncResult)
+                    {
+                        if (success)
+                        {
+                            Bridge::AdapterValueVector outParams;
+                            ConvertJxResultToOutParam(asyncResult, outParams);
+                            callback(ERROR_SUCCESS, outParams);
+                        }
+                        else
+                        {
+                            callback(ERROR_GEN_FAILURE, Bridge::AdapterValueVector());
+                        }
+                    });
+            }
+            else
+            {
+                callback(ERROR_GEN_FAILURE, Bridge::AdapterValueVector());
+            }
 
-            // Convert the result
-            ConvertJxResultToOutParam(result, outParams);
+            JX_Free(&result);
         });
     }
 
@@ -171,7 +210,7 @@ public:
         }
     }
 
-    static void ConvertJxResultToOutParam(JXValue result, Bridge::AdapterValueVector& valuesOut)
+    static void ConvertJxResultToOutParam(JXValue* result, Bridge::AdapterValueVector& valuesOut)
     {
         Bridge::PropertyValue value = nullptr;
         
@@ -184,36 +223,36 @@ public:
                     switch (ipv.Type())
                     {
                     case Bridge::PropertyType::Boolean:
-                        value = JX_GetBoolean(&result);
+                        value = JX_GetBoolean(result);
                         break;
                     case Bridge::PropertyType::UInt8:
-                        value = (uint8_t)JX_GetInt32(&result);
+                        value = (uint8_t)JX_GetInt32(result);
                         break;
                     case Bridge::PropertyType::Int16:
-                        value = (int16_t)JX_GetInt32(&result);
+                        value = (int16_t)JX_GetInt32(result);
                         break;
                     case Bridge::PropertyType::Int32:
-                        value = (int32_t)JX_GetInt32(&result);
+                        value = (int32_t)JX_GetInt32(result);
                         break;
                     case Bridge::PropertyType::Int64:
                         // Lossy conversion
-                        value = (int64_t)JX_GetInt32(&result);
+                        value = (int64_t)JX_GetInt32(result);
                         break;
                     case Bridge::PropertyType::UInt16:
-                        value = (uint16_t)JX_GetInt32(&result);
+                        value = (uint16_t)JX_GetInt32(result);
                         break;
                     case Bridge::PropertyType::UInt32:
-                        value = (uint32_t)JX_GetInt32(&result);
+                        value = (uint32_t)JX_GetInt32(result);
                         break;
                     case Bridge::PropertyType::UInt64:
                         // Lossy conversion
-                        value = (uint64_t)JX_GetInt32(&result);
+                        value = (uint64_t)JX_GetInt32(result);
                         break;
                     case Bridge::PropertyType::Double:
-                        value = JX_GetDouble(&result);
+                        value = JX_GetDouble(result);
                         break;
                     case Bridge::PropertyType::String:
-                        value = std::move(std::string(JX_GetString(&result)));
+                        value = std::move(std::string(JX_GetString(result)));
                         break;
                     default:
                         value = std::move(std::string("Not implemented: Cannot convert JX data type back to PropertyValue"));
@@ -224,6 +263,69 @@ public:
                 }
             }
         }
+    }
+
+    void GetAsyncJxResult(
+        JXValue* result,
+        std::function<void(bool,JXValue*)> resultCallback)
+    {
+        if (JX_IsObject(result))
+        {
+            JXValue resultThen;
+            JX_GetNamedProperty(result, ScriptHostConstants::Then, &resultThen);
+            bool resultIsAPromise = JX_IsFunction(&resultThen);
+            JX_Free(&resultThen);
+
+            if (resultIsAPromise)
+            {
+                // The result is an object with a then() method, so it is assumed to be a Promise.
+                // Call then() to set up success and failure callbacks via the reportResult()
+                // native method registered on the global device object.
+
+                // This call ID value could eventually roll over, and that's fine. If a device method
+                // invocation hasn't returned by the time 4 billion more have been invoked, it never will.
+                int32_t callId = ++_nextCallId;
+                _callbackMap.emplace(callId, resultCallback);
+
+                std::string callbackScript = StringUtils::Format(
+                    "(function (promise) {"
+                    "  promise.then("
+                    "    function (result) {"
+                    "      %s.%s(%d, true, result);"
+                    "    },"
+                    "    function (error) {"
+                    "      %s.%s(%d, false, error);"
+                    "    });"
+                    "})",
+                    ScriptHostConstants::DeviceObjectName, ScriptHostConstants::ReportResultName, callId,
+                    ScriptHostConstants::DeviceObjectName, ScriptHostConstants::ReportResultName, callId);
+
+                JXValue callbackFunction;
+                JX_Evaluate(callbackScript.c_str(), nullptr, &callbackFunction);
+
+                JXValue unusedResult;
+                if (!JX_CallFunction(&callbackFunction, result, 1, &unusedResult))
+                {
+                    JXValue callbackError;
+                    JX_New(&callbackError);
+                    const char message[] = "Error setting up promise callbacks.";
+                    JX_SetError(&callbackError, message, _countof(message));
+
+                    resultCallback(false, &callbackError);
+
+                    JX_Free(&callbackError);
+                }
+
+                JX_Free(&unusedResult);
+                JX_Free(&callbackFunction);
+
+                JX_Loop();
+                return;
+            }
+        }
+
+        // The result is not a Promise, so just invoke the success handler directly.
+        resultCallback(true, result);
     }
 
     static void ConvertJxValuesToAdapterValues(std::vector<JXValue>& valuesIn, Bridge::AdapterValueVector& valuesOut)
@@ -278,33 +380,18 @@ public:
         }
     }
 
-    // Call a global JavaScript function, and get the result.
-    // NOTE that due to the way JxCore handles global scope, global functions
-    // should be added to the "global" object e.g.
-    //          var myFunc = function () { ...... }
-    //          globals.myFunc = myFunc;
-    // For simplicity, this method waits for the call to complete, since the callers expect script hosts to be synchronous. 
-    // In future, this can be moved to return results asynchronously.
-    // This dispatches the call to the JxCore instance and waits for it to complete.
-    void CallScriptFunction(JXValue* result, const std::string& name, std::vector<JXValue>& params)
-    {
-        _dispatcher.DispatchAndWait([&]()
-        {
-            InternalCallScriptFunction(result, name, params);
-        });
-    }
-
 private:
 
-    void InternalCallScriptFunction(JXValue* result, const std::string& name, std::vector<JXValue>& params)
+    bool InternalCallScriptFunction(JXValue* result, const std::string& name, std::vector<JXValue>& params)
     {
         JXValue global;
         JXValue func;
         JX_GetGlobalObject(&global);
 
         JX_GetNamedProperty(&global, name.c_str(), &func);
-        JX_CallFunction(&func, params.data(), (const int) params.size(), result);
+        bool completed = JX_CallFunction(&func, params.data(), (const int) params.size(), result);
         JX_Loop();
+        return completed;
     }
 
     void SetStringProperty(JXValue* obj, const std::string& name, const std::string& value)
@@ -326,6 +413,7 @@ private:
         JX_SetNamedProperty(&global, ScriptHostConstants::DeviceObjectName, &_deviceObject);
         // Register the native methods
         JX_SetNativeMethod(&_deviceObject, ScriptHostConstants::RaiseSignalName, &RaiseSignalCallback);
+        JX_SetNativeMethod(&_deviceObject, ScriptHostConstants::ReportResultName, &ReportResultCallback);
         // Set the initial standard properties
         SetStringProperty(&_deviceObject, ScriptHostConstants::Name, pDevice->Name());
         SetStringProperty(&_deviceObject, ScriptHostConstants::Props, pDevice->Props());
@@ -360,7 +448,58 @@ private:
         JX_SetNamedProperty(&_deviceObject, ScriptHostConstants::ContextName, &ctx);
     }
 
+    static void ReportResultCallback(JXValue* argv, int argc)
+    {
+        Bridge::IAdapterDevice* pDevice = GetDeviceContext();
+        if (pDevice && pDevice->HostContext() && argc == 3)
+        {
+            ScriptHost* host = reinterpret_cast<ScriptHost*>((void*)pDevice->HostContext());
+
+            // These 3 parameters are passed in to the device.reportResult() method by the promise continuation script.
+            int32_t callId = JX_GetInt32(argv + 0);
+            bool success = JX_GetBoolean(argv + 1);
+            JXValue* pResult = argv + 2;
+
+            // Look up the result callback in the map, and call it if found.
+            // There's no need to lock access to this map since it is always accessed on the JS engine main thread.
+            auto entry = host->_callbackMap.find(callId);
+            if (entry != host->_callbackMap.end())
+            {
+                std::function<void(bool, JXValue*)> callback = entry->second;
+                host->_callbackMap.erase(callId);
+
+                callback(success, pResult);
+            }
+        }
+    }
+
     static void RaiseSignalCallback(JXValue* argv, int argc)
+    {
+        Bridge::IAdapterDevice* pDevice = GetDeviceContext();
+        if (pDevice)
+        {
+            if (argc == 1)
+            {
+                std::string signalName = JX_GetString(argv + 0);
+                pDevice->RaiseSignal(signalName);
+            }
+            else if (argc >= 2)
+            {
+                std::string signalName = JX_GetString(argv + 0);
+                std::vector<JXValue> args;
+                args.push_back(argv[1]);
+                Bridge::AdapterValueVector signalParams;
+                ConvertJxValuesToAdapterValues(args, signalParams);
+
+                if ((signalParams.size() > 0) && (signalParams[0] != nullptr))
+                {
+                    pDevice->RaiseSignal(signalName, signalParams[0].get()->Data());
+                }
+            }
+        }
+    }
+
+    static Bridge::IAdapterDevice* GetDeviceContext()
     {
         // Get get the global object and find our context object
         JXValue obj;
@@ -379,30 +518,16 @@ private:
             if (convert >> pCtx)
             {
                 Bridge::IAdapterDevice* pDevice = reinterpret_cast<Bridge::IAdapterDevice*>(pCtx);
-                if (argc == 1)
-                {
-                    std::string signalName = JX_GetString(argv + 0);
-                    pDevice->RaiseSignal(signalName);
-                }
-                else if (argc >= 2)
-                {
-                    std::string signalName = JX_GetString(argv + 0);
-                    std::vector<JXValue> args;
-                    args.push_back(argv[1]);
-                    Bridge::AdapterValueVector signalParams;
-                    ConvertJxValuesToAdapterValues(args, signalParams);
-
-                    if ((signalParams.size() > 0) && (signalParams[0] != nullptr))
-                    {
-                        pDevice->RaiseSignal(signalName, signalParams[0].get()->Data());
-                    }
-                }
-
+                return pDevice;
             }
         }
+
+        return nullptr;
     }
 
     JXValue _deviceObject;
+    std::unordered_map<int32_t, std::function<void(bool,JXValue*)>> _callbackMap;
+    int32_t _nextCallId;
     WorkItemDispatcher _dispatcher;
     //TODO: Timer to do periodic JX_Loop() calls
 };

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLib/ScriptHost.h
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLib/ScriptHost.h
@@ -174,7 +174,7 @@ public:
     // This dispatches the call to the JxCore instance and returns status asynchronously via the callback.
     void InvokePropertySetter(
         const std::string& name,
-        const std::shared_ptr<Bridge::IAdapterValue>& inParam,
+        const std::shared_ptr<Bridge::IAdapterValue> inParam,
         std::function<void(uint32_t)> callback)
     {
         _dispatcher.Dispatch([=]()

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLib/ScriptHost.h
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLib/ScriptHost.h
@@ -33,18 +33,20 @@ namespace ScriptHostConstants
     const char Description[] = "description";
     const char This[] = "This";
     const char Then[] = "then";
+    const char MainModule[] = "mainModule";
+    const char Exports[] = "exports";
     const char ContextName[] = "_adapterDeviceCtx";
 };
 
 class ScriptHost
 {
 public:
-    ScriptHost() 
+    ScriptHost()
     {
         JX_SetNull(&_deviceObject);
     }
 
-    ~ScriptHost() 
+    ~ScriptHost()
     {
         _dispatcher.DispatchAndWait([&]()
         {
@@ -82,7 +84,10 @@ public:
             JXValue result;
             std::vector<JXValue> params;
             params.emplace_back(_deviceObject);
-            if (InternalCallScriptFunction(&result, ScriptHostConstants::InitializationFunctionName, params))
+
+            uint32_t status = InternalCallScriptFunction(
+                &result, ScriptHostConstants::InitializationFunctionName, params);
+            if (status == ERROR_SUCCESS)
             {
                 GetAsyncJxResult(&result,
                     [=](bool success, JXResult* asyncResult)
@@ -92,28 +97,152 @@ public:
             }
             else
             {
-                callback(ERROR_GEN_FAILURE);
+                callback(status);
             }
 
             JX_Free(&result);
         });
     }
 
-    // Call a global JavaScript function, and get the result, converting input and output parameters
-    // to/from JXValue and PropertyValue.
-    // NOTE that due to the way JxCore handles global scope, global functions
-    // should be added to the "global" object e.g.
-    //          var myFunc = function () { ...... }
-    //          globals.myFunc = myFunc;
-    // This dispatches the call to the JxCore instance and returns status and results asynchronously via the callback.
-    // In future, this can be moved to return results asynchronously.
-    // The "insertDeviceObject" parameter, if true, adds the "device" object as the first parameter. The device object is the projected 
+    // Call a JavaScript property getter on the device module, and convert the result from JXValue to IAdapterValue.
+    // Device properties must be exported from the node module.
+    // This dispatches the call to the JxCore instance and returns status asynchronously via the callback.
+    void InvokePropertyGetter(
+        const std::string& name,
+        std::shared_ptr<Bridge::IAdapterValue> outParam,
+        std::function<void(uint32_t)> callback)
+    {
+        _dispatcher.Dispatch([=]()
+        {
+            JXValue exports;
+            GetExportsObject(&exports);
+
+            JXValue prop;
+            JX_GetNamedProperty(&exports, name.c_str(), &prop);
+            if (!JX_IsUndefined(&prop))
+            {
+                // An actual property was found. Get the value directly.
+                ConvertJxResultToOutParam(&prop, outParam);
+                callback(ERROR_SUCCESS);
+            }
+            else
+            {
+                // Check for a getProperty() method that implements the property, with appropriate casing.
+                std::locale loc;
+                std::string methodName = std::string("get") + std::toupper(name[0], loc) + name.substr(1);
+
+                JX_GetNamedProperty(&exports, methodName.c_str(), &prop);
+                if (JX_IsFunction(&prop))
+                {
+                    JXValue result;
+                    bool completed = JX_CallFunction(&prop, nullptr, 0, &result);
+                    if (completed)
+                    {
+                        GetAsyncJxResult(&result, [=](bool success, JXResult* asyncResult)
+                        {
+                            if (success)
+                            {
+                                ConvertJxResultToOutParam(asyncResult, outParam);
+                                callback(ERROR_SUCCESS);
+                            }
+                            else
+                            {
+                                callback(ERROR_GEN_FAILURE);
+                            }
+                        });
+                    }
+                    else
+                    {
+                        callback(ERROR_GEN_FAILURE);
+                    }
+
+                    JX_Free(&result);
+                }
+                else
+                {
+                    callback(ERROR_NOT_FOUND);
+                }
+            }
+
+            JX_Free(&prop);
+            JX_Free(&exports);
+        });
+    }
+
+    // Call a JavaScript property setter on the device module, converting the value from IAdapterValue to JXValue.
+    // Device properties must be exported from the node module.
+    // This dispatches the call to the JxCore instance and returns status asynchronously via the callback.
+    void InvokePropertySetter(
+        const std::string& name,
+        const std::shared_ptr<Bridge::IAdapterValue>& inParam,
+        std::function<void(uint32_t)> callback)
+    {
+        _dispatcher.Dispatch([=]()
+        {
+            // Convert the input parameter
+            std::vector<JXValue> jxInputParams;
+            Bridge::AdapterValueVector inParams(1);
+            inParams[0] = inParam;
+            ConvertPropertyValuesToJxValues(inParams, jxInputParams);
+
+            JXValue exports;
+            GetExportsObject(&exports);
+
+            JXValue prop;
+            JX_GetNamedProperty(&exports, name.c_str(), &prop);
+            if (!JX_IsUndefined(&prop))
+            {
+                // An actual property was found. Set the value directly.
+                JX_SetNamedProperty(&exports, name.c_str(), &jxInputParams[0]);
+                callback(ERROR_SUCCESS);
+            }
+            else
+            {
+                // Check for a setProperty() method that implements the property, with appropriate casing.
+                std::locale loc;
+                std::string methodName = std::string("set") + std::toupper(name[0], loc) + name.substr(1);
+
+                JX_GetNamedProperty(&exports, methodName.c_str(), &prop);
+                if (JX_IsFunction(&prop))
+                {
+                    JXValue result;
+                    bool completed = JX_CallFunction(&prop, jxInputParams.data(), 1, &result);
+                    if (completed)
+                    {
+                        GetAsyncJxResult(&result, [=](bool success, JXResult* asyncResult)
+                        {
+                            callback(success ? ERROR_SUCCESS : ERROR_GEN_FAILURE);
+                        });
+                    }
+                    else
+                    {
+                        callback(ERROR_GEN_FAILURE);
+                    }
+
+                    JX_Free(&result);
+                }
+                else
+                {
+                    callback(ERROR_NOT_FOUND);
+                }
+            }
+
+            JX_Free(&prop);
+            JX_Free(&exports);
+        });
+    }
+
+    // Call a JavaScript method on the device module, and get the result, converting input and output parameters
+    // to/from JXValue and PropertyValue. Device methods must be exported from the device node module.
+    // This dispatches the call to the JxCore instance and returns status asynchronously via the callback.
+    // The "insertDeviceObject" parameter, if true, adds the "device" object as the first parameter. The device object is the projected
     // version of the IAdapterDevice used to start this script host instance.
-    void CallScriptFunction(
+    void InvokeMethod(
         const std::string& name,
         const Bridge::AdapterValueVector& inParams,
+        std::shared_ptr<Bridge::IAdapterValue> outParam,
         bool insertDeviceObject,
-        std::function<void(uint32_t,Bridge::AdapterValueVector&)> callback)
+        std::function<void(uint32_t)> callback)
     {
         _dispatcher.Dispatch([=]()
         {
@@ -126,29 +255,28 @@ public:
             {
                 jxInputParams.insert(jxInputParams.begin(), _deviceObject);
             }
-            
+
             // Call the script function
             JXValue result;
-            if (InternalCallScriptFunction(&result, name, jxInputParams))
+            uint32_t status = InternalCallScriptFunction(&result, name, jxInputParams);
+            if (status == ERROR_SUCCESS)
             {
-                GetAsyncJxResult(&result,
-                    [=](bool success, JXResult* asyncResult)
+                GetAsyncJxResult(&result, [=](bool success, JXResult* asyncResult)
+                {
+                    if (success)
                     {
-                        if (success)
-                        {
-                            Bridge::AdapterValueVector outParams;
-                            ConvertJxResultToOutParam(asyncResult, outParams);
-                            callback(ERROR_SUCCESS, outParams);
-                        }
-                        else
-                        {
-                            callback(ERROR_GEN_FAILURE, Bridge::AdapterValueVector());
-                        }
-                    });
+                        ConvertJxResultToOutParam(asyncResult, outParam);
+                        callback(ERROR_SUCCESS);
+                    }
+                    else
+                    {
+                        callback(ERROR_GEN_FAILURE);
+                    }
+                });
             }
             else
             {
-                callback(ERROR_GEN_FAILURE, Bridge::AdapterValueVector());
+                callback(status);
             }
 
             JX_Free(&result);
@@ -210,59 +338,56 @@ public:
         }
     }
 
-    static void ConvertJxResultToOutParam(JXValue* result, Bridge::AdapterValueVector& valuesOut)
+    static void ConvertJxResultToOutParam(JXValue* result, std::shared_ptr<Bridge::IAdapterValue> valueOut)
     {
-        Bridge::PropertyValue value = nullptr;
-        
-        for (auto& valueOut : valuesOut)
+        if (valueOut == nullptr)
         {
-            if (valueOut != nullptr)
-            {
-                Bridge::PropertyValue ipv = (valueOut.get())->Data();
-                {
-                    switch (ipv.Type())
-                    {
-                    case Bridge::PropertyType::Boolean:
-                        value = JX_GetBoolean(result);
-                        break;
-                    case Bridge::PropertyType::UInt8:
-                        value = (uint8_t)JX_GetInt32(result);
-                        break;
-                    case Bridge::PropertyType::Int16:
-                        value = (int16_t)JX_GetInt32(result);
-                        break;
-                    case Bridge::PropertyType::Int32:
-                        value = (int32_t)JX_GetInt32(result);
-                        break;
-                    case Bridge::PropertyType::Int64:
-                        // Lossy conversion
-                        value = (int64_t)JX_GetInt32(result);
-                        break;
-                    case Bridge::PropertyType::UInt16:
-                        value = (uint16_t)JX_GetInt32(result);
-                        break;
-                    case Bridge::PropertyType::UInt32:
-                        value = (uint32_t)JX_GetInt32(result);
-                        break;
-                    case Bridge::PropertyType::UInt64:
-                        // Lossy conversion
-                        value = (uint64_t)JX_GetInt32(result);
-                        break;
-                    case Bridge::PropertyType::Double:
-                        value = JX_GetDouble(result);
-                        break;
-                    case Bridge::PropertyType::String:
-                        value = std::move(std::string(JX_GetString(result)));
-                        break;
-                    default:
-                        value = std::move(std::string("Not implemented: Cannot convert JX data type back to PropertyValue"));
-                        break;
-                    }
-
-                    valueOut->Data() = value;
-                }
-            }
+            // The caller is ignoring the return value.
+            return;
         }
+
+        Bridge::PropertyValue value = nullptr;
+        Bridge::PropertyValue ipv = valueOut->Data();
+        switch (ipv.Type())
+        {
+        case Bridge::PropertyType::Boolean:
+            value = JX_GetBoolean(result);
+            break;
+        case Bridge::PropertyType::UInt8:
+            value = (uint8_t)JX_GetInt32(result);
+            break;
+        case Bridge::PropertyType::Int16:
+            value = (int16_t)JX_GetInt32(result);
+            break;
+        case Bridge::PropertyType::Int32:
+            value = (int32_t)JX_GetInt32(result);
+            break;
+        case Bridge::PropertyType::Int64:
+            // Lossy conversion
+            value = (int64_t)JX_GetInt32(result);
+            break;
+        case Bridge::PropertyType::UInt16:
+            value = (uint16_t)JX_GetInt32(result);
+            break;
+        case Bridge::PropertyType::UInt32:
+            value = (uint32_t)JX_GetInt32(result);
+            break;
+        case Bridge::PropertyType::UInt64:
+            // Lossy conversion
+            value = (uint64_t)JX_GetInt32(result);
+            break;
+        case Bridge::PropertyType::Double:
+            value = JX_GetDouble(result);
+            break;
+        case Bridge::PropertyType::String:
+            value = std::move(std::string(JX_GetString(result)));
+            break;
+        default:
+            value = std::move(std::string("Not implemented: Cannot convert JX data type back to PropertyValue"));
+            break;
+        }
+
+        valueOut->Data() = value;
     }
 
     void GetAsyncJxResult(
@@ -382,16 +507,25 @@ public:
 
 private:
 
-    bool InternalCallScriptFunction(JXValue* result, const std::string& name, std::vector<JXValue>& params)
+    uint32_t InternalCallScriptFunction(JXValue* result, const std::string& name, std::vector<JXValue>& params)
     {
-        JXValue global;
-        JXValue func;
-        JX_GetGlobalObject(&global);
+        JXValue exports;
+        GetExportsObject(&exports);
 
-        JX_GetNamedProperty(&global, name.c_str(), &func);
-        bool completed = JX_CallFunction(&func, params.data(), (const int) params.size(), result);
-        JX_Loop();
-        return completed;
+        JXValue func;
+        JX_GetNamedProperty(&exports, name.c_str(), &func);
+        if (JX_IsFunction(&func))
+        {
+            bool completed = JX_CallFunction(&func, params.data(), (const int)params.size(), result);
+            JX_Loop();
+            JX_Free(&func);
+            return completed ? ERROR_SUCCESS : ERROR_GEN_FAILURE;
+        }
+        else
+        {
+            JX_Free(&func);
+            return ERROR_NOT_FOUND;
+        }
     }
 
     void SetStringProperty(JXValue* obj, const std::string& name, const std::string& value)
@@ -446,6 +580,27 @@ private:
         std::string ctxString = std::to_string(reinterpret_cast<uintptr_t>(pDevice));
         JX_SetString(&ctx, ctxString.c_str(), (const uint32_t)ctxString.length());
         JX_SetNamedProperty(&_deviceObject, ScriptHostConstants::ContextName, &ctx);
+    }
+
+    // Get the object that contains the script's exported properties and methods.
+    static void GetExportsObject(JXValue* exports)
+    {
+        JXValue process;
+        JX_GetProcessObject(&process);
+
+        JXValue module;
+        JX_GetNamedProperty(&process, ScriptHostConstants::MainModule, &module);
+        JX_Free(&process);
+
+        JX_GetNamedProperty(&module, ScriptHostConstants::Exports, exports);
+        JX_Free(&module);
+
+        if (!JX_IsObject(exports))
+        {
+            // Fallback to the global object.
+            JX_Free(exports);
+            JX_GetGlobalObject(exports);
+        }
     }
 
     static void ReportResultCallback(JXValue* argv, int argc)

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLib/pch.h
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLib/pch.h
@@ -18,6 +18,9 @@
 
 #pragma warning(disable:4127)   // conditional expression is constant
 
+#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+#include <Windows.h>
+
 #include <stdio.h>
 #include <iostream>
 

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLibUW/ScriptAdapterLibUW.vcxproj
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLibUW/ScriptAdapterLibUW.vcxproj
@@ -205,6 +205,7 @@
     <ClInclude Include="..\ScriptAdapterLib\Deps\inc\jx_result.h" />
     <ClInclude Include="..\ScriptAdapterLib\IJsAdapter.h" />
     <ClInclude Include="..\ScriptAdapterLib\JsAdapter.h" />
+    <ClInclude Include="..\ScriptAdapterLib\JsAdapterRequest.h" />
     <ClInclude Include="..\ScriptAdapterLib\ScriptHost.h" />
     <ClInclude Include="..\ScriptAdapterLib\WorkItemDispatcher.h" />
     <ClInclude Include="ScriptAdapterLibUW.h" />
@@ -213,6 +214,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\ScriptAdapterLib\JsAdapter.cpp" />
+    <ClCompile Include="..\ScriptAdapterLib\JsAdapterRequest.cpp" />
     <ClCompile Include="ScriptAdapterLibUW.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLibUW/ScriptAdapterLibUW.vcxproj.filters
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLibUW/ScriptAdapterLibUW.vcxproj.filters
@@ -17,6 +17,9 @@
     <ClCompile Include="..\ScriptAdapterLib\JsAdapter.cpp">
       <Filter>AdapterFiles</Filter>
     </ClCompile>
+    <ClCompile Include="..\ScriptAdapterLib\JsAdapterRequest.cpp">
+      <Filter>AdapterFiles</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ScriptAdapterLibUW.h" />
@@ -32,6 +35,9 @@
       <Filter>AdapterFiles</Filter>
     </ClInclude>
     <ClInclude Include="..\ScriptAdapterLib\JsAdapter.h">
+      <Filter>AdapterFiles</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ScriptAdapterLib\JsAdapterRequest.h">
       <Filter>AdapterFiles</Filter>
     </ClInclude>
     <ClInclude Include="..\ScriptAdapterLib\ScriptHost.h">

--- a/AllJoyn/Platform/Bridge/ScriptAdapterLibUW/pch.h
+++ b/AllJoyn/Platform/Bridge/ScriptAdapterLibUW/pch.h
@@ -20,6 +20,7 @@
 #include "targetver.h"
 
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+#include <Windows.h>
 
 #include <stdio.h>
 #include <iostream>

--- a/AllJoyn/Platform/BridgeRT/BridgeJs.h
+++ b/AllJoyn/Platform/BridgeRT/BridgeJs.h
@@ -21,22 +21,28 @@
 
 namespace BridgeRT
 {
-	public ref class BridgeJs sealed : public IBridgeJs
-	{
-	public:
-		BridgeJs();
+    public ref class BridgeJs sealed : public IBridgeJs
+    {
+    public:
+        BridgeJs();
 
-		virtual int32_t Initialize();
-		virtual void AddDevice(_In_ DeviceInfo ^device, _In_ Platform::String^ baseTypeXml, _In_ Platform::String^ jsScript, _In_ Platform::String^ modulesPath);
-		virtual void Shutdown();
-		event Windows::Foundation::EventHandler<Platform::String^>^ Error;
-		void RaiseEvent(Platform::String^ msg);
+        virtual int32_t Initialize();
+        virtual IAsyncAction^ AddDeviceAsync(
+            _In_ DeviceInfo ^device,
+            _In_ Platform::String^ baseTypeXml,
+            _In_ Platform::String^ jsScript,
+            _In_ Platform::String^ modulesPath);
+        virtual void Shutdown();
+        event EventHandler<Platform::String^>^ Error;
+        void RaiseEvent(Platform::String^ msg);
 
     private:
+        void CheckResult(uint32_t status);
+
         class AdapterError : public AdapterLib::IJsAdapterError
         {
         public:
             void ReportError(_In_ const std::string& msg) override;
         };
-	};
+    };
 }

--- a/AllJoyn/Platform/BridgeRT/IBridgeJs.h
+++ b/AllJoyn/Platform/BridgeRT/IBridgeJs.h
@@ -19,13 +19,18 @@
 #include "DeviceInfo.h"
 
 using namespace Platform;
+using namespace Windows::Foundation;
 
 namespace BridgeRT
 {
-	public interface class IBridgeJs
-	{
-		virtual int32_t Initialize() = 0;
-		virtual void AddDevice(_In_ DeviceInfo^ device, _In_ Platform::String^ baseTypeXml, _In_ Platform::String^ jsScript, _In_ Platform::String^ modulesPath) = 0;
-		virtual void Shutdown() = 0;
-	};
+    public interface class IBridgeJs
+    {
+        virtual int32_t Initialize() = 0;
+        virtual IAsyncAction^ AddDeviceAsync(
+            _In_ DeviceInfo^ device,
+            _In_ Platform::String^ baseTypeXml,
+            _In_ Platform::String^ jsScript,
+            _In_ Platform::String^ modulesPath) = 0;
+        virtual void Shutdown() = 0;
+    };
 }

--- a/AllJoyn/Platform/TestApps/DsbTestApp/MainWindow.xaml.cs
+++ b/AllJoyn/Platform/TestApps/DsbTestApp/MainWindow.xaml.cs
@@ -82,14 +82,14 @@ namespace DsbTestApp
                 string modPath = modulesPath.Text;
 
                 // make this async as it could take awhile
-                var s = await Task.Run(() =>
+                await Task.Run(async () =>
                 {
                     // Load the schema
                     string baseXml = System.IO.File.ReadAllText(schemaFile);
                     // Load the javascript
                     string script = System.IO.File.ReadAllText(jsFile);
 
-                    this.bridge.AddDevice(device, baseXml, script, modPath);
+                    await this.bridge.AddDeviceAsync(device, baseXml, script, modPath);
                     return 0;
                 });
                 msg.Text = "Device added";

--- a/AllJoyn/Platform/TestApps/DsbTestApp/device.js
+++ b/AllJoyn/Platform/TestApps/DsbTestApp/device.js
@@ -1,36 +1,44 @@
-function logDeviceState(device) {
+
+var device = null;
+var brightness = 0;
+
+function logDeviceState() {
     console.log("  device.name          : " + device.name);
     console.log("  device.props         : " + device.props);
 }
 
 
 module.exports = {
-    device: null,
     initDevice: function (dev) {
         console.log("Javascript initialized.");
-        this.device = dev;
-        logDeviceState(this.device);
+        device = dev;
+        logDeviceState();
     },
 
     turnOn: function () {
         console.log("turnOn called.");
-        logDeviceState(this.device);
+        brightness = 100;
+        logDeviceState();
     },
 
     turnOff: function () {
         console.log("turnOff called.");
-        logDeviceState(this.device);
-    },
-
-    setBrightness: function (brightness) {
-        console.log("setBrightness called with value: " + brightness);
-        logDeviceState(this.device);
+        brightness = 0;
+        logDeviceState();
     }
 
 }
 
-// globals for JxCore host
-global.initDevice = module.exports.initDevice;
-global.turnOn = module.exports.turnOn;
-global.turnOff = module.exports.turnOff;
-global.setBrightness = module.exports.setBrightness;
+Object.defineProperty(module.exports, "brightness", {
+    get: function () {
+        console.log("getting brightness property: " + brightness);
+        logDeviceState();
+        return brightness;
+    },
+    set: function (value) {
+        console.log("setting brightness property to: " + value);
+        brightness = value;
+        logDeviceState();
+    }
+});
+

--- a/AllJoyn/Platform/TestApps/DsbTestApp/device.xml
+++ b/AllJoyn/Platform/TestApps/DsbTestApp/device.xml
@@ -6,11 +6,10 @@
     <method name="turnOn" />
     <!-- Turn off the light -->
     <method name="turnOff" />
-    <!-- Set the brightness of the light -->
-    <method name="setBrightness">
-      <!-- Valid values range from 0 (off) to 100 (full brightness) -->
-      <arg name="brightness" type="u" direction="in" />
-    </method>
+    <!-- Get/set the brightness of the light -->
+    <!-- Valid values range from 0 (off) to 100 (full brightness) -->
+    <property name="brightness" type="u" access="readwrite">
+    </property>
     <!-- Called when there is an error during usage of this translator -->
     <signal name="error">
       <arg name="type" type="s" direction="out"/>

--- a/AllJoyn/Platform/TestApps/UwpTestApp/device.js
+++ b/AllJoyn/Platform/TestApps/UwpTestApp/device.js
@@ -7,24 +7,48 @@ function logDeviceState(device) {
 module.exports = {
     device: null,
     initDevice: function (dev) {
-        console.log("Javascript initialized.");
-        this.device = dev;
-        logDeviceState(this.device);
+        console.log("initDevice called...");
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                this.device = dev;
+                logDeviceState(this.device);
+                console.log("initDevice completed.");
+                resolve();
+            }, 1000);
+        });
     },
 
     turnOn: function () {
-        console.log("turnOn called.");
-        logDeviceState(this.device);
+        console.log("turnOn called...");
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                logDeviceState(this.device);
+                console.log("turnOn completed.");
+                resolve();
+            }, 1000);
+        });
     },
 
     turnOff: function () {
         console.log("turnOff called.");
-        logDeviceState(this.device);
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                logDeviceState(this.device);
+                console.log("turnOff completed.");
+                resolve();
+            }, 1000);
+        });
     },
 
     setBrightness: function (brightness) {
-        console.log("setBrightness called with value: " + brightness);
-        logDeviceState(this.device);
+        console.log("setBrightness(" + brightness + ") called...");
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                logDeviceState(this.device);
+                console.log("setBrightness completed.");
+                resolve();
+            }, 1000);
+        });
     }
 
 }

--- a/AllJoyn/Platform/TestApps/UwpTestApp/device.js
+++ b/AllJoyn/Platform/TestApps/UwpTestApp/device.js
@@ -1,20 +1,24 @@
-function logDeviceState(device) {
+
+var device = null;
+var brightness = 0;
+var fakeDelay = 1000;
+
+function logDeviceState() {
     console.log("  device.name          : " + device.name);
     console.log("  device.props         : " + device.props);
 }
 
 
 module.exports = {
-    device: null,
     initDevice: function (dev) {
         console.log("initDevice called...");
         return new Promise((resolve, reject) => {
             setTimeout(() => {
-                this.device = dev;
-                logDeviceState(this.device);
+                device = dev;
+                logDeviceState();
                 console.log("initDevice completed.");
                 resolve();
-            }, 1000);
+            }, fakeDelay);
         });
     },
 
@@ -22,10 +26,11 @@ module.exports = {
         console.log("turnOn called...");
         return new Promise((resolve, reject) => {
             setTimeout(() => {
-                logDeviceState(this.device);
+                brightness = 100;
+                logDeviceState();
                 console.log("turnOn completed.");
                 resolve();
-            }, 1000);
+            }, fakeDelay);
         });
     },
 
@@ -33,28 +38,34 @@ module.exports = {
         console.log("turnOff called.");
         return new Promise((resolve, reject) => {
             setTimeout(() => {
-                logDeviceState(this.device);
+                brightness = 0;
+                logDeviceState();
                 console.log("turnOff completed.");
                 resolve();
-            }, 1000);
+            }, fakeDelay);
         });
     },
 
-    setBrightness: function (brightness) {
-        console.log("setBrightness(" + brightness + ") called...");
+    getBrightness: function () {
+        console.log("getBrightness called...");
         return new Promise((resolve, reject) => {
             setTimeout(() => {
-                logDeviceState(this.device);
+                logDeviceState();
+                console.log("getBrightness completed: " + brightness);
+                resolve(brightness);
+            }, fakeDelay);
+        });
+    },
+
+    setBrightness: function (value) {
+        console.log("setBrightness(" + value + ") called...");
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                brightness = value;
+                logDeviceState();
                 console.log("setBrightness completed.");
                 resolve();
-            }, 1000);
+            }, fakeDelay);
         });
     }
-
 }
-
-// globals for JxCore host
-global.initDevice = module.exports.initDevice;
-global.turnOn = module.exports.turnOn;
-global.turnOff = module.exports.turnOff;
-global.setBrightness = module.exports.setBrightness;

--- a/AllJoyn/Platform/TestApps/UwpTestApp/device.xml
+++ b/AllJoyn/Platform/TestApps/UwpTestApp/device.xml
@@ -6,11 +6,10 @@
     <method name="turnOn" />
     <!-- Turn off the light -->
     <method name="turnOff" />
-    <!-- Set the brightness of the light -->
-    <method name="setBrightness">
-      <!-- Valid values range from 0 (off) to 100 (full brightness) -->
-      <arg name="brightness" type="u" direction="in" />
-    </method>
+    <!-- Get/set the brightness of the light -->
+    <!-- Valid values range from 0 (off) to 100 (full brightness) -->
+    <property name="brightness" type="u" access="readwrite">
+    </property>
     <!-- Called when there is an error during usage of this translator -->
     <signal name="error">
       <arg name="type" type="s" direction="out"/>


### PR DESCRIPTION
The script host now automatically detects when a JS device initialization, property getter/setter, or method invocation returns a Promise object, and in that case it gets the result via an async callback. The JS bridge is also updated to handle async results from the script host. (The core bridge code already supported async device operations via the IAdapterIoRequest out parameters.)

The BridgeRT and BridgeNet AddDevice APIs are now async and renamed to AddDeviceAsync; that is a build-breaking change to any applications that consume these APIs.

I updated the test device.js script in the WinRT test app, but not in the .NET test app. That makes it easy to test both async and non-async code paths.
