### PR TITLE
Arrays and dictionaries

### DIFF
--- a/AllJoyn/Platform/Bridge/BridgeCore/AllJoynHelper.h
+++ b/AllJoyn/Platform/Bridge/BridgeCore/AllJoynHelper.h
@@ -32,12 +32,16 @@ namespace Bridge
         template<typename T>
         static QStatus SetMsgArg(_Inout_ alljoyn_msgarg msgArg, _In_ const std::string& ajSignature, _In_ std::vector<T>& arrayArg);
         static QStatus SetMsgArg(_Inout_ alljoyn_msgarg msgArg, _In_ const std::string& ajSignature, _In_ std::vector<bool>& arrayArg);
+        static QStatus SetMsgArg(_Inout_ alljoyn_msgarg msgArg, _In_ const std::string& ajSignature, _In_ std::vector<std::string>& arrayArg);
+        static QStatus SetMsgArg(_Inout_ alljoyn_msgarg msgArg, _In_ const std::string& ajSignature, _In_ std::unordered_map<std::string, std::string>& dictArg);
 
         static QStatus SetMsgArgFromAdapterObject(_In_ std::shared_ptr<IAdapterValue> adapterValue, _Inout_ alljoyn_msgarg msgArg, _In_ DeviceMain *deviceMain);
 
         template<typename T>
         static QStatus GetArrayFromMsgArg(_In_ alljoyn_msgarg msgArg, _In_ const std::string& ajSignature, _Out_ std::vector<T>& arrayArg);
         static QStatus GetArrayFromMsgArg(_In_ alljoyn_msgarg msgArg, _In_ const std::string& ajSignature, _Out_ std::vector<bool>& arrayArg);
+        static QStatus GetArrayFromMsgArg(_In_ alljoyn_msgarg msgArg, _In_ const std::string& ajSignature, _Out_ std::vector<std::string>& arrayArg);
+        static QStatus GetDictionaryFromMsgArg(_In_ alljoyn_msgarg msgArg, _In_ const std::string& ajSignature, _Out_ std::unordered_map<std::string, std::string>& dictArg);
 
         static QStatus GetAdapterValueFromMsgArg(_In_ alljoyn_msgarg msgArg, _Out_ std::shared_ptr<IAdapterValue>& adapterValue);
         static QStatus GetPropertyTypeFromMsgArg(_In_ alljoyn_msgarg msgArg, _Out_ PropertyType& propertyType);

--- a/AllJoyn/Platform/Bridge/BridgeCore/DeviceMain.cpp
+++ b/AllJoyn/Platform/Bridge/BridgeCore/DeviceMain.cpp
@@ -100,7 +100,11 @@ QStatus DeviceMain::GetPropertyValue(_In_z_ const char* /*ifcName*/, _In_z_ cons
     }
     if ((ERROR_SUCCESS == adapterStatus) && (value != nullptr))
     {
-        AllJoynHelper::SetMsgArg(value, val);
+        status = AllJoynHelper::SetMsgArg(value, val);
+    }
+    else
+    {
+        status = ER_FAIL;
     }
     return status;
 }

--- a/AllJoyn/Platform/TestApps/UwpTestApp/device.js
+++ b/AllJoyn/Platform/TestApps/UwpTestApp/device.js
@@ -1,6 +1,8 @@
 
 var device = null;
 var brightness = 0;
+var list = [];
+var dictionary = {};
 var fakeDelay = 1000;
 
 function logDeviceState() {
@@ -67,5 +69,52 @@ module.exports = {
                 resolve();
             }, fakeDelay);
         });
+    },
+
+    getList: function () {
+        console.log("getList called...");
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                logDeviceState();
+                console.log("getList completed: " + JSON.stringify(list));
+                resolve(list);
+            }, fakeDelay);
+        });
+    },
+
+    setList: function (value) {
+        console.log("setList(" + JSON.stringify(value) + ") called...");
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                list = value;
+                logDeviceState();
+                console.log("setList completed.");
+                resolve();
+            }, fakeDelay);
+        });
+    },
+
+    getDictionary: function () {
+        console.log("getDictionary called...");
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                logDeviceState();
+                console.log("getDictionary completed: " + JSON.stringify(dictionary));
+                resolve(dictionary);
+            }, fakeDelay);
+        });
+    },
+
+    setDictionary: function (value) {
+        console.log("setDictionary(" + JSON.stringify(value) + ") called...");
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                dictionary = value;
+                logDeviceState();
+                console.log("setDictionary completed.");
+                resolve();
+            }, fakeDelay);
+        });
     }
+
 }

--- a/AllJoyn/Platform/TestApps/UwpTestApp/device.xml
+++ b/AllJoyn/Platform/TestApps/UwpTestApp/device.xml
@@ -10,6 +10,12 @@
     <!-- Valid values range from 0 (off) to 100 (full brightness) -->
     <property name="brightness" type="u" access="readwrite">
     </property>
+    <property name="list" type="as" access="readwrite">
+      <description>A string array property for testing.</description>
+    </property>
+    <property name="dictionary" type="a{ss}" access="readwrite">
+      <description>A string dictionary property for testing.</description>
+    </property>
     <!-- Called when there is an error during usage of this translator -->
     <signal name="error">
       <arg name="type" type="s" direction="out"/>


### PR DESCRIPTION
This change adds support for integer arrays, string arrays, and string dictionaries for properties, method parameters, and return values.

Other types of arrays have partial support in the JSAdapter layer but are not fully implemented in the JXCore bridge; they could be implemented easily. Support for other types of dictionaries could also be added but it would be a little more work because the design would need to be updated a bit so that all the permutations of key and value types are manageable.
